### PR TITLE
feat: add DockerHub deployment with automated CI/CD

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,64 @@
+name: Build and Push to DockerHub
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: nicolascodemate/geoloc-map
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=raw,value=latest,enable={{is_default_branch}}
+        labels: |
+          org.opencontainers.image.title=Geoloc Map
+          org.opencontainers.image.description=Symfony geolocation mapping application with FrankenPHP
+          org.opencontainers.image.vendor=Nicolas Codemate
+          
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        target: frankenphp_prod
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: |
+          BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+          VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,19 @@ CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile", "--watch" ]
 # Prod FrankenPHP image
 FROM frankenphp_base AS frankenphp_prod
 
+ARG BUILDTIME
+ARG VERSION
+ARG REVISION
+
+LABEL org.opencontainers.image.title="Geoloc Map"
+LABEL org.opencontainers.image.description="Symfony geolocation mapping application with FrankenPHP"
+LABEL org.opencontainers.image.vendor="Nicolas Codemate"
+LABEL org.opencontainers.image.created=${BUILDTIME}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.revision=${REVISION}
+LABEL org.opencontainers.image.source="https://github.com/nicolas-codemate/geoloc-map"
+LABEL org.opencontainers.image.documentation="https://github.com/nicolas-codemate/geoloc-map/blob/main/CLIENT-DEPLOYMENT.md"
+
 ENV APP_ENV=prod
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"

--- a/GEOLOC_OBJECTS.example.json
+++ b/GEOLOC_OBJECTS.example.json
@@ -1,0 +1,106 @@
+[
+  {
+    "mapName": "company_fleet",
+    "default_latitude": 48.8575,
+    "default_longitude": 2.3514,
+    "default_zoom_level": 12,
+    "refresh_interval": 10000,
+    "time_ranges": [
+      {
+        "days": [
+          "Monday",
+          "Tuesday", 
+          "Wednesday",
+          "Thursday",
+          "Friday"
+        ],
+        "start": "08:00",
+        "end": "18:00"
+      },
+      {
+        "days": [
+          "Saturday"
+        ],
+        "start": "09:00",
+        "end": "12:00"
+      }
+    ],
+    "objects": [
+      {
+        "name": "Vehicle 1 - Production API",
+        "url": "https://your-gps-api.example.com/location",
+        "query_params": {
+          "vehicle_id": "fleet_001",
+          "api_key": "your-secure-api-key",
+          "format": "json"
+        },
+        "latitude_json_path": "coordinates.lat",
+        "longitude_json_path": "coordinates.lng"
+      },
+      {
+        "name": "Vehicle 2 - Jeedom Integration",
+        "url": "https://jeedom.example.com/core/api/jeeApi.php",
+        "query_params": {
+          "apikey": "jeedom-api-key",
+          "method": "get",
+          "plugin": "jMQTT",
+          "type": "cmd",
+          "id": "[779,780]"
+        },
+        "latitude_json_path": "779",
+        "longitude_json_path": "780"
+      }
+    ]
+  },
+  {
+    "mapName": "demo_sandbox",
+    "default_latitude": 45.764043,
+    "default_longitude": 4.835659,
+    "default_zoom_level": 10,
+    "refresh_interval": 5000,
+    "objects": [
+      {
+        "name": "Demo Vehicle (Sandbox)",
+        "enable_sandbox": true
+      },
+      {
+        "name": "Another Demo Object",
+        "enable_sandbox": true
+      }
+    ]
+  },
+  {
+    "mapName": "my_personal_car",
+    "default_latitude": 48.8575,
+    "default_longitude": 2.3514,
+    "default_zoom_level": 15,
+    "refresh_interval": 30000,
+    "time_ranges": [
+      {
+        "days": [
+          "Monday",
+          "Tuesday",
+          "Wednesday", 
+          "Thursday",
+          "Friday",
+          "Saturday",
+          "Sunday"
+        ],
+        "start": "06:00",
+        "end": "23:59"
+      }
+    ],
+    "objects": [
+      {
+        "name": "My Car",
+        "url": "https://car-tracker-api.example.com/v1/position",
+        "query_params": {
+          "device_id": "car_tracker_123",
+          "token": "bearer-token-here"
+        },
+        "latitude_json_path": "location.latitude",
+        "longitude_json_path": "location.longitude"
+      }
+    ]
+  }
+]

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -10,6 +10,6 @@ services:
       - ./frankenphp/certs:/etc/caddy/certs:ro
     environment:
       SERVER_NAME: ${SERVER_NAME:-https://localhost}
-      MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}
-      MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}
+      APP_SECRET: ${APP_SECRET}
+      GEOLOC_OBJECTS: ${GEOLOC_OBJECTS}
       CADDY_SERVER_EXTRA_DIRECTIVES: ${CADDY_SERVER_EXTRA_DIRECTIVES:-}

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,19 +2,14 @@ services:
   php:
     image: geoloc-map:latest
     restart: unless-stopped
+    build:
+      context: .
+      target: frankenphp_dev
     environment:
       SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
-      MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
-      MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
-      # Run "composer require symfony/orm-pack" to install and configure Doctrine ORM
-      DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-15}&charset=${POSTGRES_CHARSET:-utf8}
-      # Run "composer require symfony/mercure-bundle" to install and configure the Mercure integration
-      MERCURE_URL: ${CADDY_MERCURE_URL:-http://php/.well-known/mercure}
-      MERCURE_PUBLIC_URL: ${CADDY_MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}:${HTTPS_PORT:-443}/.well-known/mercure}
-      MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
-      # The two next lines can be removed after initial installation
-      SYMFONY_VERSION: ${SYMFONY_VERSION:-}
-      STABILITY: ${STABILITY:-stable}
+      APP_SECRET: ${APP_SECRET:-dev_secret_change_me_in_production}
+      GEOLOC_OBJECTS: ${GEOLOC_OBJECTS:-[]}
+      CADDY_SERVER_EXTRA_DIRECTIVES: ${CADDY_SERVER_EXTRA_DIRECTIVES:-}
     volumes:
       - caddy_data:/data
       - caddy_config:/config
@@ -32,12 +27,6 @@ services:
         published: ${HTTP3_PORT:-443}
         protocol: udp
 
-# Mercure is installed as a Caddy module, prevent the Flex recipe from installing another service
-###> symfony/mercure-bundle ###
-###< symfony/mercure-bundle ###
-
 volumes:
   caddy_data:
   caddy_config:
-###> symfony/mercure-bundle ###
-###< symfony/mercure-bundle ###


### PR DESCRIPTION
- Add GitHub Actions workflow for automated Docker builds and DockerHub push
- Clean up docker-compose files removing unused PostgreSQL and Mercure dependencies
- Add missing APP_SECRET and GEOLOC_OBJECTS environment variables
- Add comprehensive client deployment documentation (CLIENT-DEPLOYMENT.md)
- Create environment template and configuration examples for clients
- Add Docker metadata labels for better image traceability
- Provide ready-to-use deployment script (docker-run-example.sh)

This enables clients to easily deploy the application using: docker run with pre-built images from DockerHub instead of local builds.

Key improvements:
- Automated multi-architecture builds (AMD64/ARM64)
- Proper versioning with Git tags
- Simplified deployment for Docker Desktop and Portainer users
- Complete documentation with examples for various deployment scenarios